### PR TITLE
Order by status to hit correct server

### DIFF
--- a/app/Http/Controllers/LookupController.php
+++ b/app/Http/Controllers/LookupController.php
@@ -12,7 +12,7 @@ class LookupController extends Controller
 	{
 		$data = null;
 		try {
-			$record = Domain::whereDomain($domain)->firstOrFail();
+			$record = Domain::whereDomain($domain)->orderBy('status')->firstOrFail();
 			$data = $record->server_name;
 		} catch (ModelNotFoundException $e) {
 			$data = __("Account not found on server");


### PR DESCRIPTION
This allows for the lookup to resolve to the correct active server if a domain has been e.g. transferred.

### Current behaviour

| domain | status | server |
| -- | -- | -- |
| domain.com | disabled | web1 |
| domain.com | active | web2 |

/lookup/domain.com => web1

### Fixed behaviour

| domain | status | server |
| -- | -- | -- |
| domain.com | disabled | web1 |
| domain.com | active | web2 |

/lookup/domain.com => web2